### PR TITLE
Fix startup crash on FastMCP 3.x and add stdio transport

### DIFF
--- a/volatility_mcp_server.py
+++ b/volatility_mcp_server.py
@@ -428,18 +428,20 @@ if __name__ == "__main__":
         sys.exit(1)
 
     try:
-        # Run the MCP server
-        port = int(os.environ.get("MCP_PORT", 8080))
-        host = os.environ.get("MCP_HOST", "0.0.0.0")
-        logger.info(f"Starting MCP server on {host}:{port}")
-        
-        asyncio.run(
-        mcp.run_sse_async(
-            host=host,
-            port=port,
-            log_level="debug"
-        )
-    )     
+        # Transport selection. mcpproxy spawns MCP servers via stdio
+        # (JSON-RPC over pipes) — that's the default. Set MCP_TRANSPORT=http
+        # to run standalone with SSE/Streamable-HTTP instead.
+        # NOTE: upstream only shipped the SSE path with the now-removed
+        # FastMCP.run_sse_async(); local patch to restore both transports.
+        transport = os.environ.get("MCP_TRANSPORT", "stdio").lower()
+        if transport in ("stdio", ""):
+            logger.info("Starting MCP server on stdio")
+            asyncio.run(mcp.run_stdio_async())
+        else:
+            port = int(os.environ.get("MCP_PORT", 8080))
+            host = os.environ.get("MCP_HOST", "0.0.0.0")
+            logger.info(f"Starting MCP server (HTTP) on {host}:{port}")
+            asyncio.run(mcp.run_http_async(host=host, port=port))
     except KeyboardInterrupt:
         logger.info("Server stopped by user")
     except Exception as e:


### PR DESCRIPTION
## Problem

Two compounding issues break the server on modern installs, especially when it's spawned by an MCP aggregator.

### 1. `AttributeError` on FastMCP 3.x

The startup block calls `mcp.run_sse_async(host=host, port=port, log_level="debug")`. On FastMCP 3.x that method no longer exists:

```
AttributeError: 'FastMCP' object has no attribute 'run_sse_async'.
Did you mean: 'run_async'?
```

The equivalent public APIs on 3.x are `run_http_async(host, port)` (Streamable-HTTP — which supersedes the old SSE path) and `run_stdio_async()` for pipe-based transport.

### 2. No stdio transport

MCP aggregators like [mcpproxy](https://github.com/smithaitufe/mcpproxy-go) and Claude Desktop (with a `command`/`args` server entry) spawn child MCP servers via **stdio** — JSON-RPC over pipes — by default. Without a stdio path on this server, those clients fail the initialize handshake:

```
MCP initialize failed for stdio transport: transport error: context deadline exceeded
```

## Fix

Replace the hardcoded SSE runner with a transport switch driven by `MCP_TRANSPORT`:

| `MCP_TRANSPORT` | Call                              | Use case                                       |
|-----------------|-----------------------------------|------------------------------------------------|
| `stdio` *(default)* | `mcp.run_stdio_async()`       | Claude Desktop, mcpproxy, most MCP clients     |
| `http`          | `mcp.run_http_async(host, port)` | Standalone deployments (supersedes SSE on 3.x) |

`MCP_HOST` / `MCP_PORT` still configure the HTTP bind (defaults unchanged: `0.0.0.0:8080`).

## Repro (before the fix)

```bash
python volatility_mcp_server.py
# AttributeError: 'FastMCP' object has no attribute 'run_sse_async'
```

## Verification (after the fix)

Dispatching a JSON-RPC `initialize` via stdio:

```bash
echo '{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}' \
  | python volatility_mcp_server.py
```

returns a valid response:

```json
{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":"2025-06-18","capabilities":{...},"serverInfo":{"name":"Volatility3Forensics","version":"3.2.4"}}}
```

Plugged into mcpproxy the server goes `connecting` → `ready` with the decorated tools enumerated as expected.

## Compatibility

- Uses the public FastMCP 3.x API (`run_stdio_async`, `run_http_async`) — no version pin needed.
- Default transport changes from the (previously broken) SSE to stdio. This is a breaking change **only** for users who relied on the nonfunctional SSE default by running the script with no env vars; they now pass `MCP_TRANSPORT=http` to get HTTP. Net effect: more deployments work out of the box, one env var to opt back in.

Happy to split into two commits (API fix + stdio addition) or rename the env var if you have a convention in mind.